### PR TITLE
Show dynamically a list of packages

### DIFF
--- a/controllers/PackageController.js
+++ b/controllers/PackageController.js
@@ -1,11 +1,30 @@
 const packageService = require('../services/packageService');
-
+const { sortPackInfoByProgress, sortPackHistoryByDate } = require('../utils');
 const PackageController = {};
 
 PackageController.getPackage = async (req, res) => {
     try {
         const packInfo = await packageService.getPackageInfo(req.params.package);
         res.status(200).json(packInfo);
+    } catch (error) {
+        res.status(404).json(error);
+    }
+};
+
+PackageController.getPackages = async (req, res) => {
+    try {
+        const packageIds = req.query.id;
+        const packInfos = [];
+        for (let index = 0; index < packageIds.length; index++) {
+            const packInfo = await packageService.getPackageInfo(packageIds[index]);
+            packInfos.push(packInfo);
+        }
+        packInfos.sort(sortPackInfoByProgress);
+        for (let index = 0; index < packInfos.length; index++) {
+            const packInfo = packInfos[index];
+            packInfo.packHistory = packInfo.packHistory.sort(sortPackHistoryByDate);
+        }
+        res.status(200).json(packInfos);
     } catch (error) {
         res.status(404).json(error);
     }

--- a/index.js
+++ b/index.js
@@ -1,30 +1,8 @@
 const express = require('express');
 const app = express();
-const getPackageInfo = require("./getPackageInfo");
-const { sortPackInfoByProgress, sortPackHistoryByDate } = require("./utils");
 const packageRouter = require('./routes/package');
 
 // routes
 app.use(packageRouter);
-
-// example: http://localhost:8081/packages?id=OH756347841BR&id=OH756347841BR
-http: app.get("/packages", async (req, res) => {
-  try {
-    const packageIds = req.query.id;
-    const packInfos = [];
-    for (let index = 0; index < packageIds.length; index++) {
-      const packInfo = await getPackageInfo(packageIds[index]);
-      packInfos.push(packInfo);
-    }
-    packInfos.sort(sortPackInfoByProgress);
-    for (let index = 0; index < packInfos.length; index++) {
-      const packInfo = packInfos[index];
-      packInfo.packHistory = packInfo.packHistory.sort(sortPackHistoryByDate);
-    }
-    res.status(200).json(packInfos);
-  } catch (error) {
-    res.status(404).json(error);
-  }
-});
 
 app.listen(process.env.PORT || 8081, () => console.log("server running"));

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 const express = require("express");
 const app = express();
 const getPackageInfo = require("./getPackageInfo");
+const { sortPackInfoByProgress, sortPackHistoryByDate } = require("./utils");
 
 //example: http://localhost:8081/package/OH756347841BR
 app.get("/package/:package", async (req, res) => {
@@ -8,6 +9,26 @@ app.get("/package/:package", async (req, res) => {
     const packInfo = await getPackageInfo(req.params.package);
 
     res.status(200).json(packInfo);
+  } catch (error) {
+    res.status(404).json(error);
+  }
+});
+
+// example: http://localhost:8081/packages?id=OH756347841BR&id=OH756347841BR
+http: app.get("/packages", async (req, res) => {
+  try {
+    const packageIds = req.query.id;
+    const packInfos = [];
+    for (let index = 0; index < packageIds.length; index++) {
+      const packInfo = await getPackageInfo(packageIds[index]);
+      packInfos.push(packInfo);
+    }
+    packInfos.sort(sortPackInfoByProgress);
+    for (let index = 0; index < packInfos.length; index++) {
+      const packInfo = packInfos[index];
+      packInfo.packHistory = packInfo.packHistory.sort(sortPackHistoryByDate);
+    }
+    res.status(200).json(packInfos);
   } catch (error) {
     res.status(404).json(error);
   }

--- a/routes/package.js
+++ b/routes/package.js
@@ -6,4 +6,7 @@ const packageController = require('../controllers/packageController');
 //example: `http://localhost:8081/package/OH756347841BR`
 router.get('/package/:package', packageController.getPackage);
 
+// example: http://localhost:8081/packages?id=OH756347841BR&id=OH756347841BR
+router.get('/packages', packageController.getPackages);
+
 module.exports = router;

--- a/utils.js
+++ b/utils.js
@@ -1,0 +1,14 @@
+const sortPackInfoByProgress = (previousPackInfo, nextPackInfo) => {
+  previousPackInfo.progress > nextPackInfo.progress ? -1 : 1;
+};
+
+const sortPackHistoryByDate = (previousPackHistory, nextPackHistory) => {
+  var previousDate = new Date(previousPackHistory.info.date);
+  var nextDate = new Date(nextPackHistory.info.date);
+  return previousDate - nextDate;
+};
+
+module.exports = {
+  sortPackInfoByProgress,
+  sortPackHistoryByDate
+};


### PR DESCRIPTION
This pull request is related to https://github.com/iagorm/brazil-correios-tracking/issues/3.  

- Added GET /packages API call that can be used with many id request pameters (e.g. http://localhost:8081/packages?id=OH756347841BR&id=OH756347841BR)
- Server response package info array is sorted by progress property and nested package info array is sorted by date